### PR TITLE
Prevent TypeErrors when checking typeOf()

### DIFF
--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -379,8 +379,8 @@ Timeline.prototype.fit = function (options) {
 Timeline.prototype.getItemRange = function () {
   // get a rough approximation for the range based on the items start and end dates
   var range = this.getDataRange();
-  var min = range.min.valueOf();
-  var max = range.max.valueOf();
+  var min = range.min;
+  var max = range.max;
   var minItem = null;
   var maxItem = null;
 


### PR DESCRIPTION
Getting valueOf() on null values results in TypeErrors. Simply removing valueOf() should be sufficient for every value that can be passed.
